### PR TITLE
fixes to make example run

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,14 @@ Example Usage:
 package main
 
 import (
-	"log"
+	"fmt"
 
 	"github.com/gocolly/colly"
-	"github.com/gocolly/colly/extensions"
 	"github.com/zolamk/colly-mongo-storage/colly/mongo"
 )
 
 func main() {
-    
+
 	c := colly.NewCollector()
 
 	storage := &mongo.Storage{
@@ -24,24 +23,19 @@ func main() {
 	}
 
 	if err := c.SetStorage(storage); err != nil {
-        panic(err)
-    }
+		panic(err)
+	}
 
+	// Find and visit all links
 	c.OnHTML("a[href]", func(e *colly.HTMLElement) {
-		q.AddURL(e.Request.AbsoluteURL(e.Attr("href")))
+		e.Request.Visit(e.Attr("href"))
 	})
 
-	c.OnResponse(func(r *colly.Response) {
-		log.Println(r.Request.URL, "\t", r.StatusCode)
+	c.OnRequest(func(r *colly.Request) {
+		fmt.Println("Visiting", r.URL)
 	})
 
-	c.OnError(func(r *colly.Response, err error) {
-		log.Println(r.Request.URL, "\t", r.StatusCode, "\nError:", err)
-    })
-    
-    c.Visit("https://www.example.com")
-    
+	c.Visit("http://go-colly.org/")
 }
-
 
 ```

--- a/colly/mongo/mongo.go
+++ b/colly/mongo/mongo.go
@@ -2,13 +2,14 @@ package mongo
 
 import (
 	"context"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"log"
 	"net/url"
 	"strconv"
 
-	"github.com/mongodb/mongo-go-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/mongodb/mongo-go-driver/x/bsonx"
+	"go.mongodb.org/mongo-driver/x/bsonx"
 )
 
 // Storage implements a MongoDB storage backend for colly
@@ -26,7 +27,7 @@ func (s *Storage) Init() error {
 
 	var err error
 
-	if s.client, err = mongo.NewClient(s.URI); err != nil {
+	if s.client, err = mongo.NewClient(options.Client().ApplyURI(s.URI)); err != nil {
 
 		return err
 


### PR DESCRIPTION
When I tried to make your example run, I had two problems:

1.  "q" is undefined in:
```q.AddURL(e.Request.AbsoluteURL(e.Attr("href")))```

2. And I get the error:
```
colly/mongo/mongo.go:9:2: code in directory /Users/mike/workspace/go/src/github.com/mongodb/mongo-go-driver/mongo expects import "go.mongodb.org/mongo-driver/mongo"
``` 

I've changed the example to match the one on colly's README here: [https://github.com/gocolly/colly]()
And I've changed mongo.go to use "go.mongodb.org/mongo-driver/mongo" instead of "github.com/mongodb/mongo-go-driver/mongo" as its mongo driver.

Thanks for building this :)